### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
+* @coapacetic @jeremyyeo @michellebaird-dbt @nicolesmith24 @ramiz-bozai-dbt @swhite-dbt @dbt-labs/training
 # Setup global owners so only specific people can change branches
-* @coapacetic @jeremyyeo @michellebaird-dbt @nicolesmith24 @ramiz-bozai-dbt @swhite-dbt


### PR DESCRIPTION
This PR amends the CODEOWNERS and appends a global codeowner to act as a fallback owner.

If this repository is no longer in use and can be archived or deleted please let us know.

Please reach out to Security Engineering if you have any questions.